### PR TITLE
Warnings as errors / Noop boost builds

### DIFF
--- a/APIIntegrationTests.cpp
+++ b/APIIntegrationTests.cpp
@@ -23,8 +23,11 @@ template <typename Success, typename Error>
 using Result = boost::variant<Success, Error>;
 
 namespace ResultStatus {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
 const int Ok = 0;
 const int Error = 1;
+#pragma clang diagnostic pop
 
 template <typename T, typename R> auto Get(R v) {
   return boost::get<T>(v);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ else()
 endif()
 
 set(GLOBAL_CXX_FLAGS "-std=c++1z -stdlib=libc++")
-set(GLOBAL_CXX_FLAGS "${GLOBAL_CXX_FLAGS} -Wall -Wextra -Wpedantic  -Wno-unused-parameter")
+set(GLOBAL_CXX_FLAGS "${GLOBAL_CXX_FLAGS} -Werror -Wall -Wextra -Wpedantic  -Wno-unused-parameter")
 set(GLOBAL_CXX_FLAGS "${GLOBAL_CXX_FLAGS} -Wno-import-preprocessor-directive-pedantic -Wno-unused-command-line-argument")
 
 add_definitions(${GLOBAL_CXX_FLAGS})

--- a/SwiftCompleter.cpp
+++ b/SwiftCompleter.cpp
@@ -261,8 +261,8 @@ using namespace ssvim;
 // it can be improved.
 static void GetOffset(CompletionContext &ctx, unsigned *offset,
                       std::string *CleanFile) {
-  unsigned line = ctx.line;
-  unsigned column = ctx.column;
+  auto line = ctx.line;
+  auto column = ctx.column;
   auto fileName = ctx.sourceFilename;
 
   std::string unsavedInput;
@@ -282,7 +282,7 @@ static void GetOffset(CompletionContext &ctx, unsigned *offset,
   while (std::getline(sourceFile, someLine)) {
     if (currentLine + 1 == line) {
       // Enumerate from the column to an interesting point
-      for (int i = column; i >= 0; i--) {
+      for (auto i = column;; i--) {
         char someChar = '\0';
         if (someLine.length() > i) {
           someChar = someLine.at(i);

--- a/build_boost.sh
+++ b/build_boost.sh
@@ -12,6 +12,11 @@ SSVIM_BUILD_DIR=$DIR/build
 BOOST_PREFIX=$SSVIM_BUILD_DIR/vendor/boost/
 BOOST_LIB_DIR=$SSVIM_BUILD_DIR/vendor/boost/lib/
 
+if [[ -d $BOOST_LIB_DIR ]] && [[ -z $CI ]]; then
+    echo "Boost probably is built, skipping"
+    exit 0
+fi
+
 mkdir -p $BOOST_LIB_DIR
 
 # Wants to build from here.


### PR DESCRIPTION
Treat warnings as errors. Not running with this is a hacky artifact of hacky prototyping.

Additionally noop boost build. It's annoying and slow for this to keep running. Don't do this where $CI ( travis sets this ).

This was [brought up during code review at YCMD](https://github.com/Valloric/ycmd/pull/487) so it should be resolved once I upgrade SwiftySwiftVim in the PR.