### PR TITLE
Fix common completion and diagnostic crashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set(CMAKE_CXX_FLAGS ${SKT_FLAGS})
 add_executable(http_server
     file_body.hpp
     Logging.hpp
+    Logging.cpp
     SemanticHTTPServer.hpp
     SemanticHTTPServer.cpp
     SwiftCompleter.hpp
@@ -100,6 +101,7 @@ add_executable(http_server
 
 add_executable(test_driver
     Logging.hpp
+    Logging.cpp
     SwiftCompleter.hpp
     SwiftCompleter.cpp
     Driver.cpp
@@ -107,6 +109,7 @@ add_executable(test_driver
 
 add_executable(integration_tests
     APIIntegrationTests.cpp
+    Logging.cpp
 )
 
 target_link_libraries(http_server ${Boost_LIBRARIES} Threads::Threads)

--- a/Logging.cpp
+++ b/Logging.cpp
@@ -1,0 +1,11 @@
+#import "Logging.hpp"
+#import <mutex>
+std::mutex ioMutex;
+
+void ssvim::Logger::writeLock() {
+  ioMutex.lock();
+}
+
+void ssvim::Logger::writeUnLock() {
+  ioMutex.unlock();
+}

--- a/Logging.hpp
+++ b/Logging.hpp
@@ -42,12 +42,20 @@ private:
   template <class Arg, class... Args>
   Logger &logArgs(LogLevel level, Arg const &arg, Args const &... args) {
     if (level == LogLevelError) {
+      writeLock();
       std::cerr << _messagePrefix << arg << std::endl;
+      writeUnLock();
     } else {
+      writeLock();
       std::cout << _messagePrefix << arg << std::endl;
+      writeUnLock();
     }
     logArgs(level, args...);
     return *this;
   }
+
+  void writeLock();
+
+  void writeUnLock();
 };
 } // namespace ssvim


### PR DESCRIPTION
This patch fix a few empty variant issues to address the known crashes
in completions and diagnostics.

The server wasn't correctly handling odd behavior from SourceKit, which
would take it down.

- Sema notifications would trigger a crash
- Empty or NULL responses would trigger a crash in both the server and client.
- Add a mutex around `std::cout` and `std::cerr`.

For now, it write empty responses for completions and diagnostics to
keep the client running. Treating errors as empty responses isn't ideal:
The old ycmd client freeze the completion at the identifier value. This
should be addressing this in the new vim client. The should eventually
(potentially) be propagated to the JSON API, and handled in the new
client.

Reproducibility:

I was able to see these errors on 8.3.2 with the old client and test
data: `ycmd/tests/swift/testdata/iOS/Basic/Basic/`. ( I think that fake
comp db is weird or something ).  Similar issues are also happing in
SwiftVimTestHost